### PR TITLE
fix: models are not dumped observing aliases

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -54,4 +54,11 @@
     uv build
   '';
 
+  scripts.sample-pipeline-run.exec = ''
+    python affinity_pipeline.py
+  '';
+
+  scripts.sample-pipeline-show.exec = ''
+    dlt pipeline affinity_pipeline show
+  '';
 }

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="dlt-source-affinity",
-    version="0.1.2",
+    version="0.1.3",
     author="Planet A GmbH",
     author_email="dev@planet-a.com",
     packages=find_packages(exclude=["tests"]),


### PR DESCRIPTION
This resulted in `interactions.from__email_address` and `interactions.from__person` to be `NULL`.