### PR TITLE
fix: declare git-hooks as an explicit devenv input

### DIFF
--- a/devenv.yaml
+++ b/devenv.yaml
@@ -8,3 +8,5 @@ inputs:
         follows: nixpkgs
   nixpkgs-unstable:
     url: github:nixos/nixpkgs/nixpkgs-unstable
+  git-hooks:
+    url: github:cachix/git-hooks.nix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ dependencies = [
 dynamic = ["version"]
 author="Planet A GmbH"
 author_email="dev@planet-a.com"
+maintainers = [
+    { name = "Mehmet Celimli", email = "mehmet@planet-a.com" }
+]
 description="A DLT source for the Affinity CRM"
 license = { text = "MIT" }
 classifiers=[


### PR DESCRIPTION
CI has been broken since it last ran (Dec 2025), unrelated to PR #22: `error: git-hooks or pre-commit-hooks input required`. devenv's git-hooks module now needs this declared explicitly as a top-level input — it used to be satisfied implicitly. devenv.lock already has a git-hooks node (pulled in transitively), so this should resolve against the existing lock, but I couldn't verify locally (no nix/devenv here) — CI on this PR is the actual test.